### PR TITLE
Do not use `hax-env`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,11 +20,6 @@ runs:
 
     - name: Install binaries
       shell: bash
-      run: nix profile install "$FLAKE"#hax "$FLAKE"#hax-env "$FLAKE"#fstar
+      run: nix profile install "$FLAKE"#hax "$FLAKE"#fstar
       env:
         FLAKE: "${{ inputs.hax_repository }}/${{ inputs.hax_reference }}"
-
-    - name: Setup environment variables
-      shell: bash
-      run: hax-env no-export >> $GITHUB_ENV
-      


### PR DESCRIPTION
This commit drops the use of `hax-env`.

This binary injects environment variables related to HACL or F* libraries. This logic is now handled in [our generic F* makefile](https://gist.github.com/W95Psp/4c304132a1f85c5af4e4959dd6b356c3).