### PR TITLE
fix: use `determinate` nix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/nix-installer-action@v4
+      with:
+        determinate: true
     - name: Install & configure Cachix
       shell: bash
       run: |


### PR DESCRIPTION
Fixes #7.
The warning is about a technical detail of what nix "distribution" is installed, this PR switches over to the one considered stable by the installed used by https://github.com/DeterminateSystems/nix-installer-action.